### PR TITLE
Add support for custom orgID and groupID

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,18 @@ Then edit `config.json`:
 ```
 {
     "email": "sXXXXXXX@ed.ac.uk",
-    "password": "your-password-here"
+    "password": "your-password-here",
+    "orgID": "8868",
+    "groupID": "8872"
 }
+```
+
+You can find `orgID` in the URL when visiting an organisation page, for example:
+
+```
+https://www.eusa.ed.ac.uk/organisation/admin/8868/
+                                             ^^^^
+                                             HERE
 ```
 
 ## run (dev)
@@ -28,4 +38,3 @@ $ node server.js
 ```bash
 $ docker build -t eusa-members-api .
 ```
-

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Then edit `config.json`:
 {
     "email": "sXXXXXXX@ed.ac.uk",
     "password": "your-password-here",
-    "orgID": "8868",
-    "groupID": "8872"
+    "orgID": 8868,
+    "groupID": 8872
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,19 @@ $ yarn install
 Then edit `config.json`:
 
 ```
+    "orgID": 8868,
+    "groupID": 8872,
+
+    "port": 3000,
+    "cachefile": "instance/cache.json"
+```
+
+And also `secret.json`:
+
+```
 {
     "email": "sXXXXXXX@ed.ac.uk",
-    "password": "your-password-here",
-    "orgID": 8868,
-    "groupID": 8872
+    "password": "your-password-here"
 }
 ```
 

--- a/instance/config.json
+++ b/instance/config.json
@@ -1,4 +1,7 @@
 {
+    "orgID": 8868,
+    "groupID": 8872,
+
     "port": 3000,
     "cachefile": "instance/cache.json"
 }

--- a/instance/secret.json
+++ b/instance/secret.json
@@ -1,4 +1,6 @@
 {
     "email": "sXXXXXXX@ed.ac.uk",
-    "password": "your-password-here"
+    "password": "your-password-here",
+    "orgID": "8868",
+    "groupID": "8872"
 }

--- a/instance/secret.json
+++ b/instance/secret.json
@@ -1,6 +1,6 @@
 {
     "email": "sXXXXXXX@ed.ac.uk",
     "password": "your-password-here",
-    "orgID": "8868",
-    "groupID": "8872"
+    "orgID": 8868,
+    "groupID": 8872
 }

--- a/instance/secret.json
+++ b/instance/secret.json
@@ -1,6 +1,4 @@
 {
     "email": "sXXXXXXX@ed.ac.uk",
-    "password": "your-password-here",
-    "orgID": 8868,
-    "groupID": 8872
+    "password": "your-password-here"
 }

--- a/scrape.js
+++ b/scrape.js
@@ -23,16 +23,17 @@ const parseNameString = name => {
 
 module.exports = opts => {
     const DEBUG = (opts && opts.debug) || false
-    const nightmare = Nightmare({ 
+    const {orgID, groupID} = opts;
+    const nightmare = Nightmare({
         show: DEBUG,
         switches: {
             'ignore-gpu-blacklist': true
         }
     })
-    
+
     return new Promise((resolve, reject) => {
         nightmare
-            .goto('https://www.eusa.ed.ac.uk/organisation/memberlist/8868/?sort=groups')
+            .goto(`https://www.eusa.ed.ac.uk/organisation/memberlist/${orgID}/?sort=groups`)
             .click('.student-login-block')
             .wait('#login')
             .type('#login', secrets.email)
@@ -41,7 +42,7 @@ module.exports = opts => {
             .wait('.member_list_group')
             .evaluate(() => {
                 // executes in browser context
-                let table = document.querySelector('.member_list_group > h3 > a[href="/organisation/editmembers/8868/8872/?from=members"]').parentElement.parentElement
+                let table = document.querySelector(`.member_list_group > h3 > a[href="/organisation/editmembers/${orgID}/${groupID}/?from=members"]`).parentElement.parentElement
 
                 table = table.querySelector('.msl_table > tbody')
 
@@ -78,4 +79,3 @@ module.exports = opts => {
             })
     })
 }
-

--- a/scrape.js
+++ b/scrape.js
@@ -63,9 +63,9 @@ module.exports = (opts = {}) => {
             .type('#password', secrets.password)
             .click('[value=" Login now "]')
             .wait('.member_list_group')
-            .evaluate(() => {
+            .evaluate(node_context => {
                 // executes in browser context
-                let table = document.querySelector(`.member_list_group > h3 > a[href="/organisation/editmembers/${orgID}/${groupID}/?from=members"]`).parentElement.parentElement
+                let table = document.querySelector(`.member_list_group > h3 > a[href="/organisation/editmembers/${node_context.orgID}/${node_context.groupID}/?from=members"]`).parentElement.parentElement
 
                 table = table.querySelector('.msl_table > tbody')
 
@@ -83,7 +83,7 @@ module.exports = (opts = {}) => {
 
                 return out
 
-            })
+            }, {orgID, groupID})
             .end()
             .then(members => {
                 // do date conversions without having to inject into the EUSA page

--- a/scrape.js
+++ b/scrape.js
@@ -21,11 +21,34 @@ const parseNameString = name => {
     }
 }
 
+const validateOpts = opts => {
+    if (!Number.isInteger(opts.orgID)) {
+        return new Error("Invalid `orgID` field - not an integer")
+    }
+
+    if (!Number.isInteger(opts.groupID)) {
+        return new Error("Invalid `groupID` field - not an integer")
+    }
+
+    if ("debug" in opts) {
+        const debug = opts.debug;
+        if (debug !== undefined && debug !== false && debug !== true) {
+            return new Error("Invalid `debug` field - expected `undefined`, `false`, or `true`")
+        }
+    }
+
+    return null;
+}
+
 module.exports = (opts = {}) => {
-    const DEBUG = opts.debug === true;
     const {orgID, groupID} = opts;
+    const validationError = validateOpts(opts)
+    if (validationError !== null) {
+        return Promise.reject(validationError)
+    }
+
     const nightmare = Nightmare({
-        show: DEBUG,
+        show: opts.debug,
         switches: {
             'ignore-gpu-blacklist': true
         }

--- a/scrape.js
+++ b/scrape.js
@@ -21,8 +21,8 @@ const parseNameString = name => {
     }
 }
 
-module.exports = opts => {
-    const DEBUG = (opts && opts.debug) || false
+module.exports = (opts = {}) => {
+    const DEBUG = opts.debug === true;
     const {orgID, groupID} = opts;
     const nightmare = Nightmare({
         show: DEBUG,

--- a/scrape.js
+++ b/scrape.js
@@ -1,9 +1,6 @@
 const Nightmare    = require('nightmare')
 const { DateTime } = require('luxon')
 
-const fs      = require('fs')
-const secrets = JSON.parse(fs.readFileSync('./instance/secret.json'))
-
 const convertFromEUSADate = edate => {
     return DateTime
         .fromFormat(edate, 'dd/MM/yyyy HH:mm')
@@ -37,6 +34,14 @@ const validateOpts = opts => {
         }
     }
 
+    if ("auth" in opts === false) {
+        return new Error("Missing `auth` object")
+    } else if (typeof opts.auth.email !== "string") {
+        return new Error(`Invalid \`auth.email\` field - expected "string", got "${typeof opts.auth.email}"`)
+    } else if (typeof opts.auth.password !== "string") {
+        return new Error(`Invalid \`auth.password\` field - expected "string", got "${typeof opts.auth.password}"`)
+    }
+
     return null;
 }
 
@@ -59,8 +64,8 @@ module.exports = (opts = {}) => {
             .goto(`https://www.eusa.ed.ac.uk/organisation/memberlist/${orgID}/?sort=groups`)
             .click('.student-login-block')
             .wait('#login')
-            .type('#login', secrets.email)
-            .type('#password', secrets.password)
+            .type('#login', opts.auth.email)
+            .type('#password', opts.auth.password)
             .click('[value=" Login now "]')
             .wait('.member_list_group')
             .evaluate(node_context => {

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@ const fs             = require('fs')
 const { DateTime }   = require('luxon')
 
 const config = JSON.parse(fs.readFileSync('./instance/config.json'))
+const secrets = JSON.parse(fs.readFileSync('./instance/secret.json'))
 
 const app            = express()
 const cachefile      = config.cachefile
@@ -12,7 +13,7 @@ const orgID          = config.orgID
 const groupID        = config.groupID
 
 const writeScrape = async () => {
-    const members = await scrape_members({orgID, groupID})
+    const members = await scrape_members({orgID, groupID, auth: secrets})
 
     const out = {
         members: members,

--- a/server.js
+++ b/server.js
@@ -8,12 +8,11 @@ const config = JSON.parse(fs.readFileSync('./instance/config.json'))
 const app            = express()
 const cachefile      = config.cachefile
 const port           = config.port
+const orgID          = config.orgID
+const groupID        = config.groupID
 
 const writeScrape = async () => {
-    const members = await scrape_members({
-        "orgID": "8868",
-        "groupID": "8872",
-    })
+    const members = await scrape_members({orgID, groupID})
 
     const out = {
         members: members,

--- a/server.js
+++ b/server.js
@@ -10,10 +10,13 @@ const cachefile      = config.cachefile
 const port           = config.port
 
 const writeScrape = async () => {
-    const members = await scrape_members()
+    const members = await scrape_members({
+        "orgID": "8868",
+        "groupID": "8872",
+    })
 
     const out = {
-        members: members, 
+        members: members,
         date: new Date().toISOString()
     }
 


### PR DESCRIPTION
Changes made:
- scrape library receives two options: `orgID` and `groupID`
- `debug` is only enabled if exactly `true`, and not some other truthy value
- the api server receives two options from `secret.json` (original values are the defaults)
- documentation for finding the `orgID` (i'm not in an org that can have groups, so can't provide docs for that, sorry)
- other (accidental) whitespace fixes: single trailing newline, no spaces at end of lines