### PR TITLE
Add api keyed requests

### DIFF
--- a/instance/config.json
+++ b/instance/config.json
@@ -1,4 +1,6 @@
 {
     "port": 3000,
-    "cachefile": "instance/cache.json"
+    "cachefile": "instance/cache.json",
+    "orgID": "8868",
+    "groupID": "8872"
 }

--- a/instance/secret.json
+++ b/instance/secret.json
@@ -1,6 +1,7 @@
 {
+    "orgID": "8868",
+    "groupID": "8872",
     "email": "sXXXXXXX@ed.ac.uk",
     "password": "your-password-here",
-    "orgID": "8868",
-    "groupID": "8872"
+    "apikey": "some-api-key"
 }

--- a/server.js
+++ b/server.js
@@ -30,8 +30,7 @@ const authenticationMiddleware = (req, res, next) => {
 app.use(authenticationMiddleware)
 
 const writeScrape = async () => {
-    console.log( orgID, groupID )
-    const members = await scrape_members({orgID, groupID, debug: true})
+    const members = await scrape_members({orgID, groupID, debug: false})
 
     const out = {
         members: members,

--- a/server.js
+++ b/server.js
@@ -15,7 +15,7 @@ const groupID   = config.groupID
 const apikey    = secrets.apikey
 
 const authenticationMiddleware = (req, res, next) => {
-    if (!('key' in req.query) || req.query.key !== apikey) {
+    if (!req.query.key || req.query.key !== apikey) {
         res
             .status(401)
             .send({
@@ -48,12 +48,18 @@ const writeScrape = async () => {
 const readScrape = () => JSON.parse(fs.readFileSync(cachefile))
 
 app.get('/api/members', (req, res) => {
-    res.json({ success: true, ...readScrape()})
+    try {
+        res.json({ success: true, ...readScrape() })
+    } except (e) {
+        res.json({ success: false, status: e.toString() })
+
+    }
 })
 
 app.get('/api/refresh', (req, res) => {
     writeScrape()
         .then(r => res.json({ success: true, ...r}))
+        .catch(e => res.json({ success: false, status: e.toString() }))
 })
 
 

--- a/server.js
+++ b/server.js
@@ -31,7 +31,14 @@ const authenticationMiddleware = (req, res, next) => {
 app.use(authenticationMiddleware)
 
 const writeScrape = async () => {
-    const members = await scrape_members({orgID, groupID, auth: secrets})
+    const members = await scrape_members({
+        orgID,
+        groupID,
+        auth: {
+            email: secrets.email,
+            password: secrets.password
+        }
+    })
 
     const out = {
         members: members,

--- a/server.js
+++ b/server.js
@@ -15,7 +15,8 @@ const groupID   = config.groupID
 const apikey    = secrets.apikey
 
 const authenticationMiddleware = (req, res, next) => {
-    if (!req.query.key || req.query.key !== apikey) {
+    const expected_header = `Bearer ${apikey}`
+    if (!req.headers.authorization || req.headers.authorization !== expected_header) {
         res
             .status(401)
             .send({
@@ -50,7 +51,7 @@ const readScrape = () => JSON.parse(fs.readFileSync(cachefile))
 app.get('/api/members', (req, res) => {
     try {
         res.json({ success: true, ...readScrape() })
-    } except (e) {
+    } catch (e) {
         res.json({ success: false, status: e.toString() })
 
     }


### PR DESCRIPTION
basing off `feature/generic-scrape-settings` as a convenience, as it is very likely that that branch will be merged.

essentially, all this does is add an authentication middleware that checks for the existence of an api key on the request query parameters.