### PR TITLE
Async/await ify all the things

### DIFF
--- a/instance/config.json
+++ b/instance/config.json
@@ -1,7 +1,6 @@
 {
     "orgID": 8868,
     "groupID": 8872,
-
     "port": 3000,
     "cachefile": "instance/cache.json"
 }

--- a/instance/config.json
+++ b/instance/config.json
@@ -1,4 +1,6 @@
 {
     "port": 3000,
-    "cachefile": "instance/cache.json"
+    "cachefile": "instance/cache.json",
+    "orgID": "8868",
+    "groupID": "8872"
 }

--- a/instance/secret.json
+++ b/instance/secret.json
@@ -1,6 +1,7 @@
 {
+    "orgID": "8868",
+    "groupID": "8872",
     "email": "sXXXXXXX@ed.ac.uk",
     "password": "your-password-here",
-    "orgID": "8868",
-    "groupID": "8872"
+    "apikey": "some-api-key"
 }

--- a/server.js
+++ b/server.js
@@ -30,8 +30,7 @@ const authenticationMiddleware = (req, res, next) => {
 app.use(authenticationMiddleware)
 
 const writeScrape = async () => {
-    console.log( orgID, groupID )
-    const members = await scrape_members({orgID, groupID, debug: true})
+    const members = await scrape_members({orgID, groupID, debug: false})
 
     const out = {
         members: members,

--- a/server.js
+++ b/server.js
@@ -31,33 +31,37 @@ const authenticationMiddleware = (req, res, next) => {
 app.use(authenticationMiddleware)
 
 const writeScrape = async () => {
-    try {
-        const members = await scrape_members({orgID, groupID, auth: secrets})
+    const members = await scrape_members({orgID, groupID, auth: secrets})
 
-        const out = {
-            members: members,
-            date: new Date().toISOString()
-        }
-
-        await fs_async.writeFile(
-            cachefile,
-            JSON.stringify(out)
-        )
-
-        return out
-    } catch(e) {
-        console.error(e)
+    const out = {
+        members: members,
+        date: new Date().toISOString()
     }
+
+    await fs_async.writeFile(
+        cachefile,
+        JSON.stringify(out)
+    )
+
+    return out
 }
 
 const readScrape = async () => JSON.parse(await fs_async.readFile(cachefile))
 
 app.get('/api/members', async (req, res) => {
-    res.json({ success: true, ...(await readScrape())})
+    try {
+        res.json({ success: true, ...(await readScrape())})
+    } catch(e) {
+        res.json({ success: false, status:e.toString()})
+    }
 })
 
 app.get('/api/refresh', async (req, res) => {
-    res.json({ success: true, ...(await writeScrape())})
+    try{
+        res.json({ success: true, ...(await writeScrape())})
+    } catch(e) {
+        res.json({ success: false, status:e.toString()})
+    }
 })
 
 

--- a/server.js
+++ b/server.js
@@ -1,7 +1,7 @@
 const express        = require('express')
 const scrape_members = require('./scrape.js')
 const fs             = require('fs')
-const fs_async       = require('fs').promises
+const fsAsync       = require('fs').promises
 const { DateTime }   = require('luxon')
 
 const readJSON = file => JSON.parse(fs.readFileSync(file))
@@ -38,7 +38,7 @@ const writeScrape = async () => {
         date: new Date().toISOString()
     }
 
-    await fs_async.writeFile(
+    await fsAsync.writeFile(
         cachefile,
         JSON.stringify(out)
     )
@@ -46,7 +46,7 @@ const writeScrape = async () => {
     return out
 }
 
-const readScrape = async () => JSON.parse(await fs_async.readFile(cachefile))
+const readScrape = async () => JSON.parse(await fsAsync.readFile(cachefile))
 
 app.get('/api/members', async (req, res) => {
     try {

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const express        = require('express')
 const scrape_members = require('./scrape.js')
 const fs             = require('fs')
+const fs_async       = require('fs').promises
 const { DateTime }   = require('luxon')
 
 const readJSON = file => JSON.parse(fs.readFileSync(file))
@@ -30,30 +31,33 @@ const authenticationMiddleware = (req, res, next) => {
 app.use(authenticationMiddleware)
 
 const writeScrape = async () => {
-    const members = await scrape_members({orgID, groupID, auth: secrets})
+    try {
+        const members = await scrape_members({orgID, groupID, auth: secrets})
 
-    const out = {
-        members: members,
-        date: new Date().toISOString()
+        const out = {
+            members: members,
+            date: new Date().toISOString()
+        }
+
+        await fs_async.writeFile(
+            cachefile,
+            JSON.stringify(out)
+        )
+
+        return out
+    } catch(e) {
+        console.error(e)
     }
-
-    fs.writeFileSync(
-        cachefile,
-        JSON.stringify(out)
-    )
-
-    return out
 }
 
-const readScrape = () => JSON.parse(fs.readFileSync(cachefile))
+const readScrape = async () => JSON.parse(await fs_async.readFile(cachefile))
 
-app.get('/api/members', (req, res) => {
-    res.json({ success: true, ...readScrape()})
+app.get('/api/members', async (req, res) => {
+    res.json({ success: true, ...(await readScrape())})
 })
 
-app.get('/api/refresh', (req, res) => {
-    writeScrape()
-        .then(r => res.json({ success: true, ...r}))
+app.get('/api/refresh', async (req, res) => {
+    res.json({ success: true, ...(await writeScrape())})
 })
 
 


### PR DESCRIPTION
Make everything (at least that can be) async/await based, which means normal thrown errors can be used, instead of variously passing around Error objects and rejecting promises. 
- Allows for failing early in the scraper without resorting to `Promise.reject`
- Async `fs` API rather than sync version wherever possible (basically not config files)