### PR TITLE
Improve EASE login speed

### DIFF
--- a/scrape.js
+++ b/scrape.js
@@ -64,8 +64,8 @@ module.exports = (opts = {}) => {
             .goto(`https://www.eusa.ed.ac.uk/organisation/memberlist/${orgID}/?sort=groups`)
             .click('.student-login-block')
             .wait('#login')
-            .type('#login', opts.auth.email)
-            .type('#password', opts.auth.password)
+            .insert('#login', opts.auth.email)
+            .insert('#password', opts.auth.password)
             .click('[value=" Login now "]')
             .wait('.member_list_group')
             .evaluate(node_context => {

--- a/server.js
+++ b/server.js
@@ -15,7 +15,7 @@ const groupID   = config.groupID
 const apikey    = secrets.apikey
 
 const authenticationMiddleware = (req, res, next) => {
-    if (!('key' in req.query) || req.query.key !== apikey) {
+    if (!req.query.key || req.query.key !== apikey) {
         res
             .status(401)
             .send({
@@ -48,12 +48,18 @@ const writeScrape = async () => {
 const readScrape = () => JSON.parse(fs.readFileSync(cachefile))
 
 app.get('/api/members', (req, res) => {
-    res.json({ success: true, ...readScrape()})
+    try {
+        res.json({ success: true, ...readScrape() })
+    } except (e) {
+        res.json({ success: false, status: e.toString() })
+
+    }
 })
 
 app.get('/api/refresh', (req, res) => {
     writeScrape()
         .then(r => res.json({ success: true, ...r}))
+        .catch(e => res.json({ success: false, status: e.toString() }))
 })
 
 

--- a/server.js
+++ b/server.js
@@ -31,7 +31,14 @@ const authenticationMiddleware = (req, res, next) => {
 app.use(authenticationMiddleware)
 
 const writeScrape = async () => {
-    const members = await scrape_members({orgID, groupID, auth: secrets})
+    const members = await scrape_members({
+        orgID,
+        groupID,
+        auth: {
+            email: secrets.email,
+            password: secrets.password
+        }
+    })
 
     const out = {
         members: members,

--- a/server.js
+++ b/server.js
@@ -15,7 +15,8 @@ const groupID   = config.groupID
 const apikey    = secrets.apikey
 
 const authenticationMiddleware = (req, res, next) => {
-    if (!req.query.key || req.query.key !== apikey) {
+    const expected_header = `Bearer ${apikey}`
+    if (!req.headers.authorization || req.headers.authorization !== expected_header) {
         res
             .status(401)
             .send({
@@ -50,7 +51,7 @@ const readScrape = () => JSON.parse(fs.readFileSync(cachefile))
 app.get('/api/members', (req, res) => {
     try {
         res.json({ success: true, ...readScrape() })
-    } except (e) {
+    } catch (e) {
         res.json({ success: false, status: e.toString() })
 
     }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,16 @@
+#! /usr/bin/env node
+
+const scraper = require('./scrape.js')
+
+const fs = require('fs')
+const readJSON = fn => JSON.parse(fs.readFileSync(fn))
+
+const config = readJSON('./instance/config.json')
+const secret = readJSON('./instance/secret.json')
+
+scraper({
+    debug: true,
+    orgID: config.orgID,
+    groupID: config.groupID,
+    auth: secret
+}).then(members => console.log(members))


### PR DESCRIPTION
Skips emulating keyboard events for typing, and directly fills out the form data.

Before:
``` 
real    0m9.166s
user    0m3.126s
sys     0m0.979s
```

After:
```
real    0m6.425s
user    0m3.093s
sys     0m1.005s
```

The mathy among you will notice this is a `29.9%` increase in speed. For the not mathy among you, it faster now.